### PR TITLE
fix: allow gateway server entries without TLS

### DIFF
--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -229,7 +229,7 @@ func (c *Controller) getNonHTTPPRedirectPortsOnGateways(gateways []*istionetwork
 
 	for _, gateway := range gateways {
 		for _, server := range gateway.Spec.Servers {
-			if !server.Tls.HttpsRedirect {
+			if server.Tls == nil || !server.Tls.HttpsRedirect {
 				ports = append(ports, server.Port.Number)
 			}
 		}


### PR DESCRIPTION
The bug was found when the following PR was merged in:

https://github.com/gccloudone-aurora/project-aurora-sdlc/pull/5