### PR TITLE
fix(controller): fixes improper use of klog.Error

### DIFF
--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -68,7 +68,7 @@ func (c *Controller) handleVirtualServiceForIngress(ingress *networkingv1.Ingres
 	if !hasIngressClassAnnotation && ingress.Spec.IngressClassName != nil {
 		ingressClass, err := c.ingressClassesLister.Get(*ingress.Spec.IngressClassName)
 		if err != nil {
-			klog.Error("error getting IngressClass %q", *ingress.Spec.IngressClassName)
+			klog.Errorf("error getting IngressClass %q", *ingress.Spec.IngressClassName)
 			return nil, err
 		}
 


### PR DESCRIPTION
This PR fixes the controller package misusing klog.Errorf, which was preventing go tests from running.